### PR TITLE
Promoters count as grey users even with host role #142

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -484,7 +484,7 @@
                 else u = API.getUser(obj);
                 if (botCreatorIDs.indexOf(u.id) > -1) return 9999;
 
-                if (u.gRole == 0) return u.role;
+                if (u.gRole < 1000) return u.role;
                 else {
                     switch (u.gRole) {
                         case 3:


### PR DESCRIPTION
FIXED my own posted bug which takes g.role like plot.member (750) or promoter (500) and overwrites u.role.
For example our room Host and CoHost got g.role PROMOTER and they could`nt use any bot function because g.role which was lower than  Promoter (500) < RDJ (1000) took control instead u.role (HOST,COHOST)